### PR TITLE
Add STS token support proposal

### DIFF
--- a/nifi-docs/src/main/asciidoc/aws-sts-token-support.adoc
+++ b/nifi-docs/src/main/asciidoc/aws-sts-token-support.adoc
@@ -1,0 +1,43 @@
+= AWS STS Token Support Proposal
+
+This document outlines the approach to add support for AWS Security Token Service (STS) temporary credentials in the AWS processors shipped with Apache NiFi.
+
+== Background
+
+NiFi 1.28.1 provides a set of processors for interacting with Amazon Web Services. Authentication is configured through the ``AWSCredentialsProviderControllerService`` which currently supports access key/secret key pairs, credentials files, named profiles and Assume Role. Support for supplying an STS session token directly is not available. Several AWS services now require using temporary credentials issued by STS, so NiFi should allow users to provide a session token in addition to access key and secret key.
+
+== Implementation Overview
+
+The following high‑level changes enable STS token support for the S3 and SQS processors (``ListS3``, ``FetchS3Object``, ``PutS3Object``, ``DeleteS3Object``, ``GetSQS``, ``PutSQS`` and ``DeleteSQS``):
+
+. **Add a new property to the credential service**
+
+   *Introduce ``SESSION_TOKEN`` property descriptor in ``AWSCredentialsProviderControllerService`` with environment expression language support and ``sensitive=true``.*
+   This property allows users to supply a temporary session token obtained from AWS STS or another credential provider.
+
+. **Update credential strategy**
+
+   *Extend ``AccessKeyPairCredentialsStrategy`` to build ``BasicSessionCredentials`` (AWS SDK v1) or ``AwsSessionCredentials`` (AWS SDK v2) when ``SESSION_TOKEN`` is provided.*
+   When the token is empty, the strategy continues to create basic credentials as today.
+
+. **Expose the property in the service descriptor list**
+
+   Include ``SESSION_TOKEN`` in ``PROPERTY_DESCRIPTORS`` of ``AWSCredentialsProviderControllerService`` so processors using the controller service automatically receive the new option.
+
+. **Adapt properties file provider (optional)**
+
+   If credential files should also support session tokens, update ``PropertiesCredentialsProvider`` to read an optional ``sessionToken`` entry and construct ``AwsSessionCredentials`` when present.
+
+== Processor Impact
+
+The S3 and SQS processors reference ``AWSCredentialsProviderService`` for authentication; no direct code changes are required in these classes. Once the controller service returns credentials including the session token, the existing AWS clients will use them transparently for requests.
+
+== Documentation Updates
+
+* Update ``aws-processors.adoc`` and the individual processor descriptions under ``nifi-aws-bundle/nifi-aws-processors/src/main/resources/docs`` to mention the new controller service property and show an example flow using STS tokens.
+* Add release notes describing the additional property and that existing flows do not require changes unless they should leverage temporary credentials.
+
+== Testing Considerations
+
+Because the modification touches the credential provider used by both AWS SDK v1 and v2 clients, regression testing should cover S3 and SQS operations with static credentials as well as temporary credentials. Automated unit tests can exercise ``AccessKeyPairCredentialsStrategy`` with and without the session token.
+

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/PropertiesCredentialsProvider.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/PropertiesCredentialsProvider.java
@@ -21,6 +21,8 @@ import org.apache.nifi.processor.exception.ProcessException;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import org.apache.nifi.util.StringUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -32,6 +34,7 @@ public class PropertiesCredentialsProvider implements AwsCredentialsProvider {
 
     private final String accessKey;
     private final String secretAccessKey;
+    private final String sessionToken;
 
     public PropertiesCredentialsProvider(final File credentialsProperties) {
         try {
@@ -50,6 +53,7 @@ public class PropertiesCredentialsProvider implements AwsCredentialsProvider {
 
                 accessKey = accountProperties.getProperty("accessKey");
                 secretAccessKey = accountProperties.getProperty("secretKey");
+                sessionToken = accountProperties.getProperty("sessionToken");
             }
         } catch (final IOException e) {
             throw new ProcessException("Failed to load AWS credentials properties " + credentialsProperties, e);
@@ -58,6 +62,10 @@ public class PropertiesCredentialsProvider implements AwsCredentialsProvider {
 
     @Override
     public AwsCredentials resolveCredentials() {
-        return AwsBasicCredentials.create(accessKey, secretAccessKey);
+        if (StringUtils.isNotBlank(sessionToken)) {
+            return AwsSessionCredentials.create(accessKey, secretAccessKey, sessionToken);
+        } else {
+            return AwsBasicCredentials.create(accessKey, secretAccessKey);
+        }
     }
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/factory/strategies/AccessKeyPairCredentialsStrategy.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/factory/strategies/AccessKeyPairCredentialsStrategy.java
@@ -19,11 +19,14 @@ package org.apache.nifi.processors.aws.credentials.provider.factory.strategies;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import org.apache.nifi.util.StringUtils;
 
 
 /**
@@ -37,7 +40,8 @@ public class AccessKeyPairCredentialsStrategy extends AbstractCredentialsStrateg
     public AccessKeyPairCredentialsStrategy() {
         super("Access Key Pair", new PropertyDescriptor[] {
             AWSCredentialsProviderControllerService.ACCESS_KEY_ID,
-            AWSCredentialsProviderControllerService.SECRET_KEY
+            AWSCredentialsProviderControllerService.SECRET_KEY,
+            AWSCredentialsProviderControllerService.SESSION_TOKEN
         });
     }
 
@@ -45,15 +49,28 @@ public class AccessKeyPairCredentialsStrategy extends AbstractCredentialsStrateg
     public AWSCredentialsProvider getCredentialsProvider(final PropertyContext propertyContext) {
         final String accessKey = propertyContext.getProperty(AWSCredentialsProviderControllerService.ACCESS_KEY_ID).evaluateAttributeExpressions().getValue();
         final String secretKey = propertyContext.getProperty(AWSCredentialsProviderControllerService.SECRET_KEY).evaluateAttributeExpressions().getValue();
-        final BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
-        return new AWSStaticCredentialsProvider(credentials);
+        final String sessionToken = propertyContext.getProperty(AWSCredentialsProviderControllerService.SESSION_TOKEN).evaluateAttributeExpressions().getValue();
+        if (StringUtils.isNotBlank(sessionToken)) {
+            final BasicSessionCredentials credentials = new BasicSessionCredentials(accessKey, secretKey, sessionToken);
+            return new AWSStaticCredentialsProvider(credentials);
+        } else {
+            final BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+            return new AWSStaticCredentialsProvider(credentials);
+        }
     }
 
     @Override
     public AwsCredentialsProvider getAwsCredentialsProvider(final PropertyContext propertyContext) {
         final String accessKey = propertyContext.getProperty(AWSCredentialsProviderControllerService.ACCESS_KEY_ID).evaluateAttributeExpressions().getValue();
         final String secretKey = propertyContext.getProperty(AWSCredentialsProviderControllerService.SECRET_KEY).evaluateAttributeExpressions().getValue();
-        return software.amazon.awssdk.auth.credentials.StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+        final String sessionToken = propertyContext.getProperty(AWSCredentialsProviderControllerService.SESSION_TOKEN).evaluateAttributeExpressions().getValue();
+        if (StringUtils.isNotBlank(sessionToken)) {
+            return software.amazon.awssdk.auth.credentials.StaticCredentialsProvider.create(
+                AwsSessionCredentials.create(accessKey, secretKey, sessionToken));
+        } else {
+            return software.amazon.awssdk.auth.credentials.StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey));
+        }
     }
 
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/service/AWSCredentialsProviderControllerService.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/service/AWSCredentialsProviderControllerService.java
@@ -134,6 +134,17 @@ public class AWSCredentialsProviderControllerService extends AbstractControllerS
         .sensitive(true)
         .build();
 
+    public static final PropertyDescriptor SESSION_TOKEN = new PropertyDescriptor.Builder()
+        .name("Session Token")
+        .displayName("Session Token")
+        .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+        .required(false)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .sensitive(true)
+        .description("AWS STS temporary session token used with Access Key authentication.")
+        .dependsOn(ACCESS_KEY_ID)
+        .build();
+
     public static final PropertyDescriptor USE_ANONYMOUS_CREDENTIALS = new PropertyDescriptor.Builder()
         .name("anonymous-credentials")
         .displayName("Use Anonymous Credentials")
@@ -268,6 +279,7 @@ public class AWSCredentialsProviderControllerService extends AbstractControllerS
         USE_DEFAULT_CREDENTIALS,
         ACCESS_KEY_ID,
         SECRET_KEY,
+        SESSION_TOKEN,
         CREDENTIALS_FILE,
         PROFILE_NAME,
         USE_ANONYMOUS_CREDENTIALS,


### PR DESCRIPTION
## Summary
- document a proposal for adding AWS STS session token support
- implement session token property on credentials provider
- extend access key pair strategy to build session credentials
- load optional token from properties credentials files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d54db72348329ae4402da4f7b660f