### PR TITLE
Add low-level Kinesis consumer

### DIFF
--- a/kinesis-low-level-design.md
+++ b/kinesis-low-level-design.md
@@ -1,0 +1,133 @@
+# Alternative Design: Low-Level AWS SDK for NiFi Kinesis Processors
+
+## Background
+
+`ConsumeKinesisStream` relies on the **Kinesis Client Library** (KCL) to manage shard
+threading, state checkpoints and record retrieval.  The processor
+initializes a `Scheduler` instance that internally creates worker threads and manages
+checkpointing via DynamoDB.  Examples of the current approach can be seen in
+`ConsumeKinesisStream.java`:
+
+```
+AWS Kinesis Client Library can take several seconds to initialise before starting to fetch data.
+```
+【F:nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java†L124-L130】
+
+and the worker startup logic:
+
+```
+scheduler = prepareScheduler(context, sessionFactory, schedulerId);
+new Thread(scheduler, SCHEDULER_THREAD_NAME_TEMPLATE + schedulerId).start();
+```
+【F:nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java†L606-L616】
+
+Dynamic properties allow direct configuration of the KCL builder:
+
+```
+@DynamicProperty(name = "Kinesis Client Library (KCL) Configuration property name", ... )
+```
+【F:nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java†L145-L155】
+
+Using KCL hides the polling mechanism and shard control within the library.  NiFi
+has limited visibility and is unable to align scheduling or checkpoints directly
+with the flow.
+
+## Proposed Approach
+
+Implement a new processor (e.g. `GetKinesisRecords`) that uses the lower level
+`KinesisClient` or `KinesisAsyncClient` APIs instead of KCL.  The processor will
+explicitly poll each shard and maintain sequence checkpoints using NiFi's
+`StateManager` or DynamoDB if desired.  The following features are proposed:
+
+1. **Shard Enumeration & Iterators**
+   * On schedule, list stream shards via `ListShards` and store shard IDs in
+     processor state.
+   * For each shard, obtain a `ShardIterator` using the configured starting
+     strategy (`TRIM_HORIZON`, `LATEST`, or `AT_TIMESTAMP`).
+   * Persist the last sequence number (or iterator) for each shard in state so
+     that restarts continue from the correct position.
+
+2. **Polling Loop in onTrigger**
+   * `onTrigger` will iterate over tracked shards and invoke
+     `GetRecords` (or the asynchronous `SubscribeToShard`) with a configurable
+     max record count and wait time.
+   * The NiFi scheduling period defines polling frequency, allowing back pressure
+     and load management without KCL threads.
+   * Retrieved records are converted to FlowFiles similarly to the existing
+     `AbstractKinesisRecordProcessor` implementations.
+
+3. **Checkpoint Handling**
+   * After successful FlowFile transfer, update the sequence number for each
+     shard in `StateManager`.
+   * Optionally provide a DynamoDB checkpoint service for compatibility with
+     existing environments.
+   * Provide properties for retry count and interval when fetching or updating
+     checkpoints.
+
+4. **Record and Batch Modes**
+   * Support the same Record Reader / Record Writer options already present in
+     `ConsumeKinesisStream` so FlowFiles may contain individual records or
+     batches.
+   * Attributes such as shard ID, sequence number and approximate arrival
+     timestamp are added in the same manner.
+
+5. **NiFi‑Managed Concurrency**
+   * Since there is no scheduler thread pool inside the processor, each
+     `onTrigger` invocation runs within NiFi’s standard scheduling framework.
+   * The number of concurrent tasks configured for the processor directly
+     controls parallelism, and there are no hidden threads.
+
+6. **Simplified Configuration**
+   * Without KCL, there is no need for dynamic property injection of KCL
+     configuration.  Processor properties will expose only the options relevant
+     to direct Kinesis calls (stream name, iterator type, batch size, etc.).
+
+## Benefits
+
+* **Predictable Resource Usage** – All work happens within NiFi’s own threads,
+  so administrators have full visibility into CPU and memory requirements.
+* **Custom Checkpoint Strategy** – Checkpoints can be stored in NiFi state or a
+  user‑supplied service, allowing tighter control over exactly-once delivery and
+  easier troubleshooting.
+* **Reduced Dependencies** – Eliminates the KCL and DynamoDB requirement for
+  simple use cases where NiFi alone can track progress.
+* **Flexible Back Pressure** – Polling frequency and batch sizes can be tuned
+  directly from processor settings without interacting with KCL internals.
+
+## High Level Class Sketch
+
+```java
+public class GetKinesisRecords extends AbstractAwsSyncProcessor<KinesisClient, KinesisClientBuilder> {
+    // Properties: stream name, iterator type, timestamp, max records, etc.
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        // list shards and initialize iterators using StateManager
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) {
+        // for each shard -> GetRecords -> create FlowFiles -> update checkpoints
+    }
+
+    @Override
+    protected KinesisClientBuilder createClientBuilder(final ProcessContext context) {
+        return KinesisClient.builder();
+    }
+}
+```
+
+Record handling can reuse the existing `KinesisRecordProcessorRaw` and
+`KinesisRecordProcessorRecord` classes with minor adjustments so that they work
+without the `ShardRecordProcessor` interface.
+
+## Migration Considerations
+
+* Existing `ConsumeKinesisStream` remains for KCL‑based implementations that
+  require its advanced failover features.
+* The new processor targets simpler scenarios where NiFi developers want
+  complete control over polling and checkpoints.
+* Documentation should highlight differences in delivery guarantees and required
+  configuration compared to the current processor.
+
+---

--- a/nifi-docs/src/main/asciidoc/aws-processors.adoc
+++ b/nifi-docs/src/main/asciidoc/aws-processors.adoc
@@ -42,6 +42,7 @@ This document provides an overview of the Amazon Web Services (AWS) processors d
 == Amazon Kinesis
 * PutKinesisStream
 * ConsumeKinesisStream
+* GetKinesisRecords
 * PutKinesisFirehose
 
 == Amazon DynamoDB

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/GetKinesisRecords.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/GetKinesisRecords.java
@@ -1,0 +1,199 @@
+package org.apache.nifi.processors.aws.kinesis.stream;
+
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.Stateful;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.state.Scope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.aws.kinesis.stream.record.AbstractKinesisRecordProcessor;
+import org.apache.nifi.processors.aws.v2.AbstractAwsSyncProcessor;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.KinesisClientBuilder;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorResponse;
+import software.amazon.awssdk.services.kinesis.model.ListShardsRequest;
+import software.amazon.awssdk.services.kinesis.model.ListShardsResponse;
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.services.kinesis.model.Shard;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Processor that retrieves records from Kinesis using the AWS SDK without the Kinesis Client Library.
+ */
+@Tags({"amazon", "aws", "kinesis", "get", "stream"})
+@InputRequirement(Requirement.INPUT_FORBIDDEN)
+@CapabilityDescription("Retrieves records from an Amazon Kinesis stream using the AWS SDK." +
+        " Checkpoints are managed using NiFi state so that the processor resumes from the last successfully" +
+        " processed sequence number.")
+@SeeAlso({PutKinesisStream.class, ConsumeKinesisStream.class})
+@Stateful(scopes = Scope.CLUSTER, description = "Stores the last processed sequence number for each shard")
+public class GetKinesisRecords extends AbstractAwsSyncProcessor<KinesisClient, KinesisClientBuilder> {
+
+    static final AllowableValue LATEST = new AllowableValue("LATEST", "Latest", "Read from the latest data");
+    static final AllowableValue TRIM_HORIZON = new AllowableValue("TRIM_HORIZON", "Trim Horizon", "Read from the oldest available data");
+    static final AllowableValue AT_TIMESTAMP = new AllowableValue("AT_TIMESTAMP", "At Timestamp", "Read starting at the specified timestamp");
+
+    static final PropertyDescriptor KINESIS_STREAM_NAME = new PropertyDescriptor.Builder()
+            .name("kinesis-stream-name")
+            .displayName("Amazon Kinesis Stream Name")
+            .description("The name of Kinesis Stream")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    static final PropertyDescriptor INITIAL_STREAM_POSITION = new PropertyDescriptor.Builder()
+            .name("Initial Stream Position")
+            .description("Initial position to read Kinesis stream shards")
+            .allowableValues(LATEST, TRIM_HORIZON, AT_TIMESTAMP)
+            .defaultValue(LATEST.getValue())
+            .required(true)
+            .build();
+
+    static final PropertyDescriptor STREAM_POSITION_TIMESTAMP = new PropertyDescriptor.Builder()
+            .name("Stream Position Timestamp")
+            .description("Timestamp position in stream from which to start reading records when 'At Timestamp' is selected")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .dependsOn(INITIAL_STREAM_POSITION, AT_TIMESTAMP)
+            .build();
+
+    static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
+            .name("Batch Size")
+            .description("Maximum number of records to retrieve per request")
+            .required(true)
+            .defaultValue("1000")
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .build();
+
+    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            KINESIS_STREAM_NAME,
+            INITIAL_STREAM_POSITION,
+            STREAM_POSITION_TIMESTAMP,
+            BATCH_SIZE,
+            REGION,
+            AWS_CREDENTIALS_PROVIDER_SERVICE,
+            TIMEOUT,
+            PROXY_CONFIGURATION_SERVICE,
+            ENDPOINT_OVERRIDE
+    );
+
+    private final Map<String, String> shardIterators = new HashMap<>();
+    private final Set<String> shardIds = new HashSet<>();
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    public void onScheduled(final ProcessContext context) {
+        super.onScheduled(context);
+        shardIterators.clear();
+        shardIds.clear();
+
+        final KinesisClient client = getClient(context);
+        final String streamName = context.getProperty(KINESIS_STREAM_NAME).getValue();
+        final Map<String, String> state;
+        try {
+            state = context.getStateManager().getState(Scope.CLUSTER).toMap();
+        } catch (IOException e) {
+            throw new ProcessException("Failed to obtain state", e);
+        }
+
+        final ListShardsResponse shards = client.listShards(ListShardsRequest.builder().streamName(streamName).build());
+        for (Shard shard : shards.shards()) {
+            shardIds.add(shard.shardId());
+            final GetShardIteratorRequest.Builder iteratorRequest = GetShardIteratorRequest.builder()
+                    .streamName(streamName)
+                    .shardId(shard.shardId());
+            final String sequence = state.get("sequence." + shard.shardId());
+            if (sequence != null) {
+                iteratorRequest.shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
+                        .startingSequenceNumber(sequence);
+            } else {
+                final String position = context.getProperty(INITIAL_STREAM_POSITION).getValue();
+                iteratorRequest.shardIteratorType(ShardIteratorType.fromValue(position));
+                if (AT_TIMESTAMP.getValue().equals(position)) {
+                    final String timestamp = context.getProperty(STREAM_POSITION_TIMESTAMP).getValue();
+                    if (timestamp != null) {
+                        Instant instant = DateTimeFormatter.ISO_DATE_TIME.parse(timestamp, Instant::from);
+                        iteratorRequest.timestamp(instant);
+                    }
+                }
+            }
+            final GetShardIteratorResponse response = client.getShardIterator(iteratorRequest.build());
+            shardIterators.put(shard.shardId(), response.shardIterator());
+        }
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        final KinesisClient client = getClient(context);
+        final int batchSize = context.getProperty(BATCH_SIZE).asInteger();
+        final Map<String, String> newState = new HashMap<>();
+
+        for (final String shardId : shardIds) {
+            String iterator = shardIterators.get(shardId);
+            if (iterator == null) {
+                continue;
+            }
+
+            final GetRecordsResponse response = client.getRecords(GetRecordsRequest.builder()
+                    .shardIterator(iterator)
+                    .limit(batchSize)
+                    .build());
+
+            for (Record record : response.records()) {
+                FlowFile flowFile = session.create();
+                session.write(flowFile, out -> out.write(record.data().asByteArray()));
+                final Map<String, String> attrs = Map.of(
+                        AbstractKinesisRecordProcessor.AWS_KINESIS_SHARD_ID, shardId,
+                        AbstractKinesisRecordProcessor.AWS_KINESIS_SEQUENCE_NUMBER, record.sequenceNumber(),
+                        AbstractKinesisRecordProcessor.AWS_KINESIS_PARTITION_KEY, record.partitionKey(),
+                        AbstractKinesisRecordProcessor.AWS_KINESIS_APPROXIMATE_ARRIVAL_TIMESTAMP, record.approximateArrivalTimestamp().toString()
+                );
+                flowFile = session.putAllAttributes(flowFile, attrs);
+                session.transfer(flowFile, REL_SUCCESS);
+                newState.put("sequence." + shardId, record.sequenceNumber());
+            }
+
+            iterator = response.nextShardIterator();
+            shardIterators.put(shardId, iterator);
+        }
+
+        if (!newState.isEmpty()) {
+            try {
+                context.getStateManager().setState(newState, Scope.CLUSTER);
+            } catch (IOException e) {
+                throw new ProcessException("Failed to store state", e);
+            }
+        }
+    }
+
+    @Override
+    protected KinesisClientBuilder createClientBuilder(final ProcessContext context) {
+        return KinesisClient.builder();
+    }
+}

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -32,6 +32,7 @@ org.apache.nifi.processors.aws.dynamodb.PutDynamoDBRecord
 org.apache.nifi.processors.aws.dynamodb.DeleteDynamoDB
 org.apache.nifi.processors.aws.kinesis.stream.PutKinesisStream
 org.apache.nifi.processors.aws.kinesis.stream.ConsumeKinesisStream
+org.apache.nifi.processors.aws.kinesis.stream.GetKinesisRecords
 org.apache.nifi.processors.aws.cloudwatch.PutCloudWatchMetric
 org.apache.nifi.processors.aws.ml.translate.StartAwsTranslateJob
 org.apache.nifi.processors.aws.ml.translate.GetAwsTranslateJobStatus


### PR DESCRIPTION
## Summary
- implement GetKinesisRecords processor using AWS SDK directly
- register processor and document it in list of AWS processors
- include design document for low-level consumer approach
- fix imports and cleanup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f61f1fb908329a2a53dbcb988e530